### PR TITLE
Add typing_extensions dependency to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "scipy>=1.16.1",
     "typer-slim>=0.20.0",
     "xarray>=2025.10.1",
+    "typing_extensions>=4.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Fix missing dependency for typing_extensions

Closes #3 